### PR TITLE
Don't suspend aggregation for new contacts

### DIFF
--- a/src/com/android/providers/contacts/ContactsProvider2.java
+++ b/src/com/android/providers/contacts/ContactsProvider2.java
@@ -3093,7 +3093,7 @@ public class ContactsProvider2 extends AbstractContactsProvider
         mSyncToMetadataNetWork |= callerIsSyncAdapter;
 
         final int aggregationMode = getIntValue(values, RawContacts.AGGREGATION_MODE,
-                RawContacts.AGGREGATION_MODE_SUSPENDED);
+                RawContacts.AGGREGATION_MODE_DEFAULT);
         mAggregator.get().markNewForAggregation(rawContactId, aggregationMode);
 
         // Trigger creation of a Contact based on this RawContact at the end of transaction.


### PR DESCRIPTION
New contacts are not merged with existing contacts until they are
edited. Set the default aggregation mode to AGGREGATION_MODE_DEFAULT
to have them merged right away.

Change-Id: I18a5d32ca01daa2abc913843a094a82823cf61c3
(cherry picked from commit 4417d18292bf81fa013242919ae41a9fd5a008cf)